### PR TITLE
docs: use shallow clone in exercise 0 for faster setup

### DIFF
--- a/exercises/00-introduction-setup.md
+++ b/exercises/00-introduction-setup.md
@@ -44,20 +44,16 @@ If you don't have Go installed, or your version is older than 1.24.6:
 
 ## 📥 Step 2: Clone the Go Source Code
 
-Let's clone the official Go repository. This might take a few minutes as it's a large repository. ⏳
+Let's clone the official Go repository. We use `--depth 1` to avoid downloading the full history, making the clone much faster: ⚡️
+
+For consistency across the workshop, we'll use Go version 1.25.1. 📌
 
 ```bash
-git clone https://go.googlesource.com/go
+git clone --depth 1 --branch go1.25.1 https://go.googlesource.com/go
 cd go
 ```
 
-## 🏷️ Step 3: Checkout Go Version 1.25.1
-
-For consistency across the workshop, we'll use Go version 1.25.1. Let's check out the specific release tag: 📌
-
-```bash
-git checkout go1.25.1
-```
+## 🏷️ Step 3: Verify Go Version 1.25.1
 
 Verify you're on the correct version:
 
@@ -69,8 +65,7 @@ git describe --tags
 ## 🎓 What We Accomplished
 
 - ✅ Installed or verified Go 1.24.6+ for bootstrapping
-- ✅ Cloned the official Go repository
-- ✅ Checked out Go version 1.25.1 for consistency
+- ✅ Cloned the official Go repository at version 1.25.1
 - ✅ Environment is ready for building Go from source
 
 ## ➡️ Next Steps

--- a/website/00-introduction-setup.html
+++ b/website/00-introduction-setup.html
@@ -104,18 +104,15 @@
 
 <h2>📥 Step 2: Clone the Go Source Code</h2>
 
-<p>Let&rsquo;s clone the official Go repository. This might take a few minutes as it&rsquo;s a large repository. ⏳</p>
+<p>Let&rsquo;s clone the official Go repository. We use <code>--depth 1</code> to avoid downloading the full history, making the clone much faster: ⚡️</p>
 
-<pre><code class="language-bash">git clone https://go.googlesource.com/go
+<p>For consistency across the workshop, we&rsquo;ll use Go version 1.25.1. 📌</p>
+
+<pre><code class="language-bash">git clone --depth 1 --branch go1.25.1 https://go.googlesource.com/go
 cd go
 </code></pre>
 
-<h2>🏷️ Step 3: Checkout Go Version 1.25.1</h2>
-
-<p>For consistency across the workshop, we&rsquo;ll use Go version 1.25.1. Let&rsquo;s check out the specific release tag: 📌</p>
-
-<pre><code class="language-bash">git checkout go1.25.1
-</code></pre>
+<h2>🏷️ Step 3: Verify Go Version 1.25.1</h2>
 
 <p>Verify you&rsquo;re on the correct version:</p>
 
@@ -127,8 +124,7 @@ cd go
 
 <ul>
 <li>✅ Installed or verified Go 1.24.6+ for bootstrapping</li>
-<li>✅ Cloned the official Go repository</li>
-<li>✅ Checked out Go version 1.25.1 for consistency</li>
+<li>✅ Cloned the official Go repository at version 1.25.1</li>
 <li>✅ Environment is ready for building Go from source</li>
 </ul>
 


### PR DESCRIPTION
**Description**
This PR updates the exercise 0 setup instructions to use:

```bash
git clone --depth 1 --branch go1.25.1 https://go.googlesource.com/go
```

instead of cloning the full repository and checking out `go1.25.1` afterward.

Why this change:

* It fetches only the selected tag instead of the repository’s full history.
* It should reduce setup time and bandwidth usage.

What changed:

* Replaced the full `git clone` command with a shallow clone targeting `go1.25.1`
* Removed the separate `git checkout go1.25.1` step