### PR TITLE
fix: regenerate website HTML to reflect typo fixes from PR #2

### DIFF
--- a/website/02-scanner-arrow-operator.html
+++ b/website/02-scanner-arrow-operator.html
@@ -132,7 +132,7 @@ case '=':
 
 <ul>
 <li><strong><code>if s.ch == '&gt;'</code></strong>: Check if the next character after &ldquo;=&rdquo; is &ldquo;&gt;&rdquo;</li>
-<li><strong><code>s.nextch()</code></strong>: comsumes the &ldquo;&gt;&rdquo; character from the lexer</li>
+<li><strong><code>s.nextch()</code></strong>: consumes the &ldquo;&gt;&rdquo; character from the lexer</li>
 <li><strong><code>s.lit = &quot;=&gt;&quot;</code></strong>: Set the literal value for debugging/error messages</li>
 <li><strong><code>s.tok = _Go</code></strong>: Assign the same token as the &ldquo;go&rdquo; keyword</li>
 <li><strong><code>break</code></strong>: Exit the case to avoid falling through to <code>_Assign</code></li>

--- a/website/04-compiler-inlining-parameters.html
+++ b/website/04-compiler-inlining-parameters.html
@@ -398,7 +398,7 @@ echo &quot;Default vs No-inline: $(echo &quot;scale=2; ($default_size - $no_inli
 
 <h2>➡️ Next Steps</h2>
 
-<p>Excellent work! 🎉 You&rsquo;ve learned how to tune Go&rsquo;s inlining behavior and seen its real-world impact on binary size and performance. In the next exercises, we&rsquo;ll explore modifiying the gofmt tool.</p>
+<p>Excellent work! 🎉 You&rsquo;ve learned how to tune Go&rsquo;s inlining behavior and seen its real-world impact on binary size and performance. In the next exercises, we&rsquo;ll explore modifying the gofmt tool.</p>
 
 <h2>🧹 Cleanup</h2>
 

--- a/website/06-ssa-power-of-two-detector.html
+++ b/website/06-ssa-power-of-two-detector.html
@@ -83,7 +83,7 @@
 <li><strong>Code Generation</strong> - Produce machine code</li>
 </ol>
 
-<p>We are going to work with the SSA form to know about the posibility of optimizing powers of two.</p>
+<p>We are going to work with the SSA form to know about the possibility of optimizing powers of two.</p>
 
 <h2>🔍 Step 1: Understanding SSA Pass Structure</h2>
 
@@ -244,7 +244,7 @@ func main() {
 
 <p>For detailed information about each detection:</p>
 
-<pre><code class="language-bash">GOSSAFUNC=testDivisions ../go/bin/go build -gcflags=&quot;-d=ssa/detect div by power of two/debug=1&quot; test_divisions.go
+<pre><code class="language-bash">GOSSAFUNC=testDivisions ../go/bin/go build -gcflags=&quot;-d=ssa/detect_div_by_power_of_two/debug=1&quot; test_divisions.go
 </code></pre>
 
 <p><strong>Expected output:</strong></p>

--- a/website/09-predictable-select.html
+++ b/website/09-predictable-select.html
@@ -176,14 +176,14 @@ pollorder[norder] = pollorder[j]
 pollorder[j] = uint16(i)
 
 // Change to:
-pullorder[norder] = uint16(len(scases)-1-i)
+pollorder[norder] = uint16(len(scases)-1-i)
 </code></pre>
 
 <h3>🔧 Understanding the Code Change</h3>
 
 <ul>
-<li><strong><code>uint16(len(scases)-1-i)</code></strong>: Use inverse orther here</li>
-<li><strong>Result</strong>: pullorder is now always ordered in the source code order</li>
+<li><strong><code>uint16(len(scases)-1-i)</code></strong>: Use inverse order here</li>
+<li><strong>Result</strong>: pollorder is now always ordered in the source code order</li>
 <li><strong>Effect</strong>: Cases maintain their source code order in <code>pollorder</code></li>
 </ul>
 

--- a/website/10-java-style-stack-traces.html
+++ b/website/10-java-style-stack-traces.html
@@ -70,7 +70,7 @@
 
 <h2>🧠 Background: Stack Trace Styles</h2>
 
-<p>We&rsquo;re transforming Go&rsquo;s stracktrace format:</p>
+<p>We&rsquo;re transforming Go&rsquo;s stacktrace format:</p>
 
 <pre><code>panic: Something went wrong
 


### PR DESCRIPTION
I just ran `make website` all the credits goes to #2 