### PR TITLE
Add exercise 11: D&D Work Stealing - Rolling for Goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Welcome to an interactive workshop where you'll learn how to modify and experime
 
 ## Workshop Overview
 
-This workshop consists of 10 exercises that will take you through the process from building Go from source, and making modifications at different places in the compiler, tooling and runtime. You'll gain some insights about the Go internals, from things like the lexer or parser, to runtime behaviors:
+This workshop consists of 11 exercises that will take you through the process from building Go from source, and making modifications at different places in the compiler, tooling and runtime. You'll gain some insights about the Go internals, from things like the lexer or parser, to runtime behaviors:
 
 ### [Exercise 0: Introduction and Setup](./exercises/00-introduction-setup.md)
 
@@ -59,6 +59,10 @@ Modify Go's select statement implementation to be deterministic instead of rando
 ### [Exercise 10: Java-Style Stack Traces - Making Go Panics Look Familiar](./exercises/10-java-style-stack-traces.md)
 
 Transform Go's verbose stack traces into Java-style formatting.
+
+### [Exercise 11: D&D Work Stealing - Rolling for Goroutines](./exercises/11-dnd-work-stealing.md)
+
+Add a dice roll to the scheduler's work stealing algorithm - P's must roll above 10 on a d20 to steal goroutines.
 
 ## Getting Started
 

--- a/exercises/01-compile-go-unchanged.es.md
+++ b/exercises/01-compile-go-unchanged.es.md
@@ -212,5 +212,6 @@ Puedes continuar con cualquiera de los siguientes ejercicios para aprender sobre
 - [Ejercicio 8: Detective de Goroutines Dormidas - Monitoreo del Estado del Runtime](./08-goroutine-sleep-detective.md) - Monitoreo del scheduler
 - [Ejercicio 9: Select Predecible - Eliminar la Aleatoriedad del Select de Go](./09-predictable-select.md) - Comportamiento del select
 - [Ejercicio 10: Stack Traces al Estilo Java - Hacer que los Panics de Go se Vean Familiares](./10-java-style-stack-traces.md) - Formato de errores
+- [Ejercicio 11: D&D Work Stealing - Tirando Dados por Goroutines](./11-dnd-work-stealing.md) - Work stealing del scheduler
 
 O vuelve al [taller principal](../README.md) para elegir un ejercicio.

--- a/exercises/01-compile-go-unchanged.md
+++ b/exercises/01-compile-go-unchanged.md
@@ -212,5 +212,6 @@ You can now proceed with any of the following exercises to learn about different
 - [Exercise 8: Goroutine Sleep Detective - Runtime State Monitoring](./08-goroutine-sleep-detective.md) - Scheduler monitoring
 - [Exercise 9: Predictable Select - Removing Randomness from Go's Select Statement](./09-predictable-select.md) - Select behavior
 - [Exercise 10: Java-Style Stack Traces - Making Go Panics Look Familiar](./10-java-style-stack-traces.md) - Error formatting
+- [Exercise 11: D&D Work Stealing - Rolling for Goroutines](./11-dnd-work-stealing.md) - Scheduler work stealing
 
 Or return to the [main workshop](../README.md) to choose an exercise.

--- a/exercises/10-java-style-stack-traces.es.md
+++ b/exercises/10-java-style-stack-traces.es.md
@@ -235,4 +235,4 @@ Exception in thread "main" go.runtime.Panic: ...
 
 ---
 
-*¡Felicidades por completar todos los ejercicios del taller! Vuelve al [taller principal](../README.md)*
+*Continúa con el [Ejercicio 11](11-dnd-work-stealing.md) o vuelve al [taller principal](../README.md)*

--- a/exercises/10-java-style-stack-traces.md
+++ b/exercises/10-java-style-stack-traces.md
@@ -235,4 +235,4 @@ Exception in thread "main" go.runtime.Panic: ...
 
 ---
 
-*Congratulations on completing all workshop exercises! Return to the [main workshop](../README.md)*
+*Continue to [Exercise 11](11-dnd-work-stealing.md) or return to the [main workshop](../README.md)*

--- a/exercises/11-dnd-work-stealing.md
+++ b/exercises/11-dnd-work-stealing.md
@@ -1,0 +1,253 @@
+# Exercise 11: D&D Work Stealing - Rolling for Goroutines
+
+> **Want to learn more?** Read [The Scheduler](https://internals-for-interns.com/posts/go-runtime-scheduler/) on Internals for Interns for a deep dive into Go's runtime and goroutine scheduling.
+
+In this exercise, you'll add a d20 dice roll to the Go scheduler's work stealing algorithm. When a processor (P) tries to steal goroutines from another P's run queue, it must first roll above 10 on a twenty-sided die. Failed rolls mean the steal is blocked, making the scheduler's work distribution visible and entertaining.
+
+## Learning Objectives
+
+By the end of this exercise, you will:
+
+- Understand how Go's work stealing scheduler distributes goroutines across processors
+- Know where the `stealWork` function lives and how it iterates over other P's
+- Modify the steal logic to add a randomized gate
+- Observe work stealing attempts in real time
+
+## Background: Work Stealing
+
+Go's scheduler uses work stealing to balance load across processors. When a P runs out of goroutines to execute, it looks at other P's queues and steals half their work:
+
+```
+Before (current behavior):
+  P0: [g1, g2, g3, g4]    P1: []  (idle)
+  P1 tries to steal from P0 → always succeeds
+  P0: [g1, g2]             P1: [g3, g4]
+
+After (our modification):
+  P0: [g1, g2, g3, g4]    P1: []  (idle)
+  P1 rolls d20 to steal from P0 → rolled 7, failed!
+  P1 rolls d20 to steal from P0 → rolled 16, stole!
+  P0: [g1, g2]             P1: [g3, g4]
+```
+
+## Step 1: Understanding the Steal Mechanism
+
+The work stealing logic lives in the `stealWork` function in `proc.go`:
+
+```bash
+cd go/src/runtime
+grep -n "func stealWork" proc.go
+```
+
+You'll find `stealWork` around line 3828. This function is called by `findRunnable` when a P has no local work. It iterates over other P's in a randomized order, trying to steal goroutines from their run queues.
+
+## Step 2: Find the Steal Attempt
+
+Inside `stealWork`, look for the actual steal attempt around line 3883:
+
+```bash
+grep -n "runqsteal" proc.go | head -5
+```
+
+You'll see this code block (around line 3883-3887):
+
+```go
+// go/src/runtime/proc.go:3883-3887
+// Don't bother to attempt to steal if p2 is idle.
+if !idlepMask.read(enum.position()) {
+    if gp := runqsteal(pp, p2, stealTimersOrRunNextG); gp != nil {
+        return gp, false, now, pollUntil, ranTimer
+    }
+}
+```
+
+Key variables at this point:
+- **`pp`** - The current P (the thief), type `*p`, has field `pp.id` (int32)
+- **`p2`** - The target P (the victim), type `*p`, has field `p2.id`
+- **`runqsteal(pp, p2, ...)`** - Moves goroutines from p2's queue to pp's queue
+
+## Step 3: Add the D&D Dice Roll
+
+Replace lines 3883-3887 with our dice-gated version:
+
+```go
+// go/src/runtime/proc.go:3883-3887
+// Don't bother to attempt to steal if p2 is idle.
+if !idlepMask.read(enum.position()) {
+    if mainStarted && gogetenv("GODND") != "" {
+        // D&D Work Stealing: Roll a d20 to attempt stealing!
+        roll := cheaprandn(20) + 1 // Roll 1-20
+        if roll > 10 {
+            if gp := runqsteal(pp, p2, stealTimersOrRunNextG); gp != nil {
+                println("🎲 [P", pp.id, "] Rolling to steal from P", p2.id, "... rolled", roll, ". Stole!")
+                return gp, false, now, pollUntil, ranTimer
+            }
+        } else {
+            println("🎲 [P", pp.id, "] Rolling to steal from P", p2.id, "... rolled", roll, ". Failed!")
+        }
+    } else {
+        if gp := runqsteal(pp, p2, stealTimersOrRunNextG); gp != nil {
+            return gp, false, now, pollUntil, ranTimer
+        }
+    }
+}
+```
+
+### Understanding the Code
+
+- **`mainStarted`** - A boolean already in `proc.go` that flips to `true` early in the main goroutine's startup — before `sysmon`, GC, and `init()` run. It cuts out the very earliest scheduler noise, but some pre-main prints will still appear (see the callout below)
+- **`gogetenv("GODND")`** - The runtime's internal env var reader (equivalent of `os.Getenv` — the runtime can't import `os`). Gates everything behind `GODND=1` so the scheduler behaves normally unless you opt in
+- **`cheaprandn(20) + 1`** - Rolls 1-20. `cheaprandn(20)` returns 0-19, the `+ 1` shifts it to a proper d20 range
+- **`roll > 10`** - 50% success rate (rolls 11-20 succeed, rolls 1-10 fail)
+- **`println(...)`** - Runtime's builtin print function, writes to stderr via raw syscall, no imports needed
+- **`pp.id` / `p2.id`** - The processor ID fields (int32), defined in the `p` struct in `runtime2.go`
+- We only print "Stole!" when `runqsteal` returns non-nil (the target queue might have emptied between the idle check and the steal)
+
+> **🐉 Fun fact: The scheduler already rolls with advantage — times four!**
+>
+> Look at the outer loop in `stealWork`: `const stealTries = 4`. The scheduler doesn't just try to steal once — it loops **4 times** over all P's, re-shuffling the order with `cheaprand()` each pass. So your d20 gate doesn't just get rolled once per steal attempt — a determined P gets up to 4 chances per target. In D&D terms, that's rolling with advantage... squared.
+>
+> And the 4th pass is special: it sets `stealTimersOrRunNextG = true`, which unlocks stealing the victim's `runnext` goroutine — the one it was about to run next. The source code comment literally says *"stealing from the other P's runnext should be the last resort."* So the final pass is the desperate, gloves-off round where everything is fair game.
+>
+> The Go scheduler was already playing D&D before you got here. You're just making the dice visible.
+
+## Step 4: Rebuild Go Toolchain
+
+```bash
+cd ../  # back to go/src
+./make.bash
+```
+
+## Step 5: Test the D&D Scheduler
+
+Create the `dnd_steal_demo.go` file:
+
+```bash
+# Create the file
+touch /tmp/dnd_steal_demo.go
+```
+
+```go
+package main
+
+import (
+    "runtime"
+    "sync"
+)
+
+func busyWork(id int, wg *sync.WaitGroup) {
+    defer wg.Done()
+    sum := 0
+    for i := 0; i < 1_000_000; i++ {
+        sum += i
+    }
+    println("Goroutine", id, "finished")
+}
+
+func main() {
+    runtime.GOMAXPROCS(4) // 4 P's for visible stealing
+    println("=== D&D Work Stealing Demo ===")
+    println()
+
+    var wg sync.WaitGroup
+    for i := 1; i <= 20; i++ {
+        wg.Add(1)
+        go busyWork(i, &wg)
+    }
+    wg.Wait()
+    println()
+    println("=== All goroutines completed! ===")
+}
+```
+
+Build and run with D&D mode enabled:
+
+```bash
+../go/bin/go build -o dnd_steal_demo /tmp/dnd_steal_demo.go
+GODND=1 ./dnd_steal_demo
+```
+
+**Why `GODND=1`?** Without it, the scheduler runs normally — no dice rolls, no prints. This keeps `./make.bash` and `go build` clean and silent. Note that some pre-main and post-main prints will still appear even with `GODND=1` — see the callouts below for why.
+
+**Why build first then run?** The `go build` command itself uses your modified Go. Building separately (without `GODND=1`) keeps the compiler's work stealing silent.
+
+Expected output (varies every run):
+
+```
+🎲 [P 3 ] Rolling to steal from P 0 ... rolled 13 . Stole!
+=== D&D Work Stealing Demo ===
+
+🎲 [P 2 ] Rolling to steal from P 0 ... rolled 15 . Stole!
+🎲 [P 3 ] Rolling to steal from P 0 ... rolled 12 . Stole!
+🎲 [P 1 ] Rolling to steal from P 0 ... rolled 11 . Stole!
+Goroutine 15 finished
+🎲 [P 0 ] Rolling to steal from P 2 ... rolled 7 . Failed!
+🎲 [P 0 ] Rolling to steal from P 3 ... rolled 20 . Stole!
+Goroutine 1 finished
+Goroutine 12 finished
+...
+=== All goroutines completed! ===
+🎲 [P %
+```
+
+You'll see the dice rolls interleaved with goroutine completion messages. Rolls of 1-10 fail, rolls of 11-20 succeed. Notice how a P with no work keeps retrying different targets until it rolls high enough!
+
+> **📖 Why are there dice rolls before `=== D&D Work Stealing Demo ===`?**
+>
+> You didn't write those — the Go runtime did. Between `mainStarted` flipping to `true` and your first `println`, the runtime starts `sysmon`, enables the GC, and runs all `init()` functions — each spawning goroutines that idle P's immediately try to steal. You've instrumented the scheduler itself, so you're now seeing activity that was always there, just silent.
+
+> **📖 Why is there a truncated `🎲 [P %` after `=== All goroutines completed! ===`?**
+>
+> Same story, other end. After `wg.Wait()` returns, the idle P's are still spinning in `stealWork` looking for more work. One starts a `println` just as `main()` returns and the process exits — the print never finishes. The `%` is your shell saying the output didn't end with a newline. The scheduler doesn't stop for you on the way out either.
+
+> Welcome to the inside of Go!
+
+
+## Understanding What We Did
+
+1. **Found the Steal Logic**: Located `stealWork` in `proc.go` where P's steal goroutines from each other
+2. **Added a Dice Gate**: Used `cheaprandn(20) + 1` to generate a d20 roll (1-20) before each steal attempt
+3. **Logged the Rolls**: Added `println()` calls showing which P is stealing from which, the roll result, and whether it succeeded
+4. **Observed the Effect**: Saw work stealing attempts in real time, with some failing due to low rolls
+
+## What We Learned
+
+- **Work Stealing**: How Go distributes goroutines across processors when queues are imbalanced
+- **`stealWork` Function**: The core loop that iterates over P's looking for work to steal
+- **`cheaprandn`**: The runtime's fast pseudo-random number generator, used throughout the scheduler
+- **Scheduler Observability**: How to add logging to the scheduler without breaking its behavior
+- **P Identity**: Each processor has a unique `id` field that identifies it in scheduling decisions
+
+## Extension Ideas
+
+1. Make the difficulty configurable: roll must beat 15 instead of 10 (harder steals)
+2. Add a "critical hit" on natural 20: steal ALL goroutines from target, not just half
+3. Add a "fumble" on natural 1: the stealing P yields for one cycle with `Gosched()`
+4. Track and print total rolls, successes, and failures at program exit
+
+## Cleanup
+
+To remove the dice roll:
+
+```bash
+cd go/src/runtime
+git checkout proc.go
+cd ../
+./make.bash
+```
+
+## Summary
+
+You've turned Go's work stealing scheduler into a tabletop RPG encounter:
+
+```
+Before:  P tries to steal -> always succeeds if target has work
+After:   P tries to steal -> must roll > 10 on a d20 first
+
+Changes: runtime/proc.go stealWork() function (~14 lines)
+Result:  The scheduler now plays D&D!
+```
+
+---
+
+*Congratulations on completing all workshop exercises! Return to the [main workshop](../README.md)*

--- a/website-generator/main.go
+++ b/website-generator/main.go
@@ -53,38 +53,38 @@ type LangConfig struct {
 }
 
 type UIStrings struct {
-	Home              string
-	Previous          string
-	Next              string
-	Exercise          string
-	HeroTitle         string
-	HeroLead          string
-	HeroVersionNote   string
-	Prerequisites     string
-	PrereqItems       []string
-	Overview          string
-	OverviewText      string
-	GettingStarted    string
+	Home                string
+	Previous            string
+	Next                string
+	Exercise            string
+	HeroTitle           string
+	HeroLead            string
+	HeroVersionNote     string
+	Prerequisites       string
+	PrereqItems         []string
+	Overview            string
+	OverviewText        string
+	GettingStarted      string
 	GettingStartedItems []string
-	Tips              string
-	TipItems          []string
-	Resources         string
-	VideoReferences   string
-	VideoRefsIntro    string
-	VideoCompiler     string
-	VideoCompilerDesc string
-	VideoRuntime      string
-	VideoRuntimeDesc  string
-	Completion        string
-	CompletionIntro   string
-	CompletionItems   []string
-	CompletionCongrats string
-	CompletionEnables []string
-	Contributing      string
-	ContributingText  string
-	CTAButton         string
-	FooterTitle       string
-	FooterCreatedBy   string
+	Tips                string
+	TipItems            []string
+	Resources           string
+	VideoReferences     string
+	VideoRefsIntro      string
+	VideoCompiler       string
+	VideoCompilerDesc   string
+	VideoRuntime        string
+	VideoRuntimeDesc    string
+	Completion          string
+	CompletionIntro     string
+	CompletionItems     []string
+	CompletionCongrats  string
+	CompletionEnables   []string
+	Contributing        string
+	ContributingText    string
+	CTAButton           string
+	FooterTitle         string
+	FooterCreatedBy     string
 }
 
 var englishConfig = LangConfig{
@@ -105,16 +105,17 @@ var englishConfig = LangConfig{
 		{"08-goroutine-sleep-detective", "Goroutine Sleep Detective - Runtime State Monitoring", "Add logging to the Go scheduler to monitor goroutines going to sleep."},
 		{"09-predictable-select", "Predictable Select - Removing Randomness from Go's Select Statement", "Modify Go's select statement implementation to be deterministic instead of random."},
 		{"10-java-style-stack-traces", "Java-Style Stack Traces - Making Go Panics Look Familiar", "Transform Go's verbose stack traces into Java-style formatting."},
+		{"11-dnd-work-stealing", "D&D Work Stealing - Rolling for Goroutines", "Add a d20 dice roll to Go's work stealing scheduler to gate goroutine theft between processors."},
 	},
 	UIStrings: UIStrings{
-		Home:              "Home",
-		Previous:          "Previous",
-		Next:              "Next",
-		Exercise:          "Exercise",
-		HeroTitle:         "Having fun with the Go Source Code",
-		HeroLead:          "Welcome to an interactive workshop where you'll learn how to modify and experiment with the Go programming language source code! This hands-on workshop will guide you through understanding, building, and making changes to the Go compiler and runtime.",
-		HeroVersionNote:   "<strong>This workshop uses Go version 1.26.1</strong> - we'll check out the specific release tag to ensure consistency across all exercises.",
-		Prerequisites:     "Prerequisites",
+		Home:            "Home",
+		Previous:        "Previous",
+		Next:            "Next",
+		Exercise:        "Exercise",
+		HeroTitle:       "Having fun with the Go Source Code",
+		HeroLead:        "Welcome to an interactive workshop where you'll learn how to modify and experiment with the Go programming language source code! This hands-on workshop will guide you through understanding, building, and making changes to the Go compiler and runtime.",
+		HeroVersionNote: "<strong>This workshop uses Go version 1.26.1</strong> - we'll check out the specific release tag to ensure consistency across all exercises.",
+		Prerequisites:   "Prerequisites",
 		PrereqItems: []string{
 			"Basic knowledge of Go programming",
 			"Familiarity with command line tools",
@@ -122,8 +123,8 @@ var englishConfig = LangConfig{
 			"<strong>Go compiler version 1.24 or newer</strong> (required for bootstrapping the build process)",
 			"At least 4GB of free disk space",
 		},
-		Overview:     "Workshop Overview",
-		OverviewText: "This workshop consists of %d exercises that will take you through the process from building Go from source, and making modifications at different places in the compiler, tooling and runtime. You'll gain some insights about the Go internals, from things like the lexer or parser, to runtime behaviors:",
+		Overview:       "Workshop Overview",
+		OverviewText:   "This workshop consists of %d exercises that will take you through the process from building Go from source, and making modifications at different places in the compiler, tooling and runtime. You'll gain some insights about the Go internals, from things like the lexer or parser, to runtime behaviors:",
 		GettingStarted: "Getting Started",
 		GettingStartedItems: []string{
 			`Start with <a href="%s00-introduction-setup.html">Exercise 0</a> to set up your environment`,
@@ -189,14 +190,14 @@ var spanishConfig = LangConfig{
 		{"10-java-style-stack-traces", "Stack Traces Estilo Java - Haciendo los Panics de Go Familiares", "Transforma los stack traces verbosos de Go al formato estilo Java."},
 	},
 	UIStrings: UIStrings{
-		Home:              "Inicio",
-		Previous:          "Anterior",
-		Next:              "Siguiente",
-		Exercise:          "Ejercicio",
-		HeroTitle:         "Divirtiéndonos con el Código Fuente de Go",
-		HeroLead:          "¡Bienvenido a un taller interactivo donde aprenderás a modificar y experimentar con el código fuente del lenguaje de programación Go! Este taller práctico te guiará a través de la comprensión, compilación y modificación del compilador y runtime de Go.",
-		HeroVersionNote:   "<strong>Este taller usa Go versión 1.26.1</strong> - haremos checkout del tag de release específico para asegurar consistencia en todos los ejercicios.",
-		Prerequisites:     "Prerrequisitos",
+		Home:            "Inicio",
+		Previous:        "Anterior",
+		Next:            "Siguiente",
+		Exercise:        "Ejercicio",
+		HeroTitle:       "Divirtiéndonos con el Código Fuente de Go",
+		HeroLead:        "¡Bienvenido a un taller interactivo donde aprenderás a modificar y experimentar con el código fuente del lenguaje de programación Go! Este taller práctico te guiará a través de la comprensión, compilación y modificación del compilador y runtime de Go.",
+		HeroVersionNote: "<strong>Este taller usa Go versión 1.26.1</strong> - haremos checkout del tag de release específico para asegurar consistencia en todos los ejercicios.",
+		Prerequisites:   "Prerrequisitos",
 		PrereqItems: []string{
 			"Conocimientos básicos de programación en Go",
 			"Familiaridad con herramientas de línea de comandos",
@@ -204,8 +205,8 @@ var spanishConfig = LangConfig{
 			"<strong>Compilador de Go versión 1.24 o superior</strong> (necesario para el proceso de bootstrapping)",
 			"Al menos 4GB de espacio libre en disco",
 		},
-		Overview:     "Descripción General del Taller",
-		OverviewText: "Este taller consta de %d ejercicios que te llevarán a través del proceso desde compilar Go desde el código fuente hasta hacer modificaciones en diferentes partes del compilador, herramientas y runtime. Obtendrás conocimientos sobre los internos de Go, desde cosas como el lexer o parser, hasta comportamientos del runtime:",
+		Overview:       "Descripción General del Taller",
+		OverviewText:   "Este taller consta de %d ejercicios que te llevarán a través del proceso desde compilar Go desde el código fuente hasta hacer modificaciones en diferentes partes del compilador, herramientas y runtime. Obtendrás conocimientos sobre los internos de Go, desde cosas como el lexer o parser, hasta comportamientos del runtime:",
 		GettingStarted: "Cómo Empezar",
 		GettingStartedItems: []string{
 			`Comienza con el <a href="%s00-introduction-setup.html">Ejercicio 0</a> para configurar tu entorno`,
@@ -273,7 +274,7 @@ func main() {
 	}
 
 	// Create output directory if it doesn't exist
-	if err := os.MkdirAll(*outputDir, 0755); err != nil {
+	if err := os.MkdirAll(*outputDir, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating output directory: %v\n", err)
 		os.Exit(1)
 	}
@@ -284,7 +285,7 @@ func main() {
 		langOutputDir := *outputDir
 		if lang.OutputPrefix != "" {
 			langOutputDir = filepath.Join(*outputDir, lang.OutputPrefix)
-			if err := os.MkdirAll(langOutputDir, 0755); err != nil {
+			if err := os.MkdirAll(langOutputDir, 0o755); err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating output directory for %s: %v\n", lang.Code, err)
 				os.Exit(1)
 			}
@@ -468,7 +469,7 @@ func copyCSSFile(outputDir string) error {
 	cssContent := cssTemplate
 	outputPath := filepath.Join(outputDir, "style.css")
 
-	if err := os.WriteFile(outputPath, []byte(cssContent), 0644); err != nil {
+	if err := os.WriteFile(outputPath, []byte(cssContent), 0o644); err != nil {
 		return fmt.Errorf("writing CSS file: %w", err)
 	}
 

--- a/website/01-compile-go-unchanged.html
+++ b/website/01-compile-go-unchanged.html
@@ -284,6 +284,7 @@ func main() {
 <li><a href="08-goroutine-sleep-detective.html">Exercise 8: Goroutine Sleep Detective - Runtime State Monitoring</a> - Scheduler monitoring</li>
 <li><a href="09-predictable-select.html">Exercise 9: Predictable Select - Removing Randomness from Go&rsquo;s Select Statement</a> - Select behavior</li>
 <li><a href="10-java-style-stack-traces.html">Exercise 10: Java-Style Stack Traces - Making Go Panics Look Familiar</a> - Error formatting</li>
+<li><a href="11-dnd-work-stealing.html">Exercise 11: D&amp;D Work Stealing - Rolling for Goroutines</a> - Scheduler work stealing</li>
 </ul>
 
 <p>Or return to the <a href="index.html">main workshop</a> to choose an exercise.</p>

--- a/website/10-java-style-stack-traces.html
+++ b/website/10-java-style-stack-traces.html
@@ -284,7 +284,7 @@ Exception in thread &quot;main&quot; go.runtime.Panic: ...
 
 <hr />
 
-<p><em>Congratulations on completing all workshop exercises! Return to the <a href="index.html">main workshop</a></em></p>
+<p><em>Continue to <a href="11-dnd-work-stealing.html">Exercise 11</a> or return to the <a href="index.html">main workshop</a></em></p>
 
         </article>
 
@@ -292,6 +292,8 @@ Exception in thread &quot;main&quot; go.runtime.Panic: ...
             
             <a href="09-predictable-select.html" class="nav-button">← Previous</a>
             
+            
+            <a href="11-dnd-work-stealing.html" class="nav-button">Next: Exercise 11 →</a>
             
         </nav>
     </div>

--- a/website/11-dnd-work-stealing.html
+++ b/website/11-dnd-work-stealing.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Exercise 11: D&amp;D Work Stealing - Rolling for Goroutines - Go Source Code Workshop</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/go.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            hljs.highlightAll();
+
+            
+            document.querySelectorAll('pre').forEach(function(pre) {
+                const button = document.createElement('button');
+                button.className = 'copy-button';
+                button.innerHTML = '<i class="far fa-copy"></i>';
+                button.title = 'Copy to clipboard';
+
+                button.addEventListener('click', function() {
+                    const code = pre.querySelector('code');
+                    const text = code.textContent;
+
+                    navigator.clipboard.writeText(text).then(function() {
+                        button.innerHTML = '<i class="fas fa-check"></i>';
+                        button.classList.add('copied');
+                        setTimeout(function() {
+                            button.innerHTML = '<i class="far fa-copy"></i>';
+                            button.classList.remove('copied');
+                        }, 2000);
+                    }).catch(function(err) {
+                        console.error('Failed to copy:', err);
+                    });
+                });
+
+                pre.appendChild(button);
+            });
+        });
+    </script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="container">
+            <a href="index.html" class="nav-home">Having fun with the Go Source Code</a>
+            <div class="nav-links">
+                <a href="index.html">Home</a>
+                <a href="es/11-dnd-work-stealing.html" class="lang-switch"><i class="fas fa-globe"></i> Español</a>
+                <a href="https://github.com/jespino/having-fun-with-the-go-source-code-workshop" target="_blank"><i class="fab fa-github"></i> Repository</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container">
+        <article class="exercise-content">
+            <h1>Exercise 11: D&amp;D Work Stealing - Rolling for Goroutines</h1>
+
+<blockquote>
+<p><strong>Want to learn more?</strong> Read <a href="https://internals-for-interns.com/posts/go-runtime-scheduler/">The Scheduler</a> on Internals for Interns for a deep dive into Go&rsquo;s runtime and goroutine scheduling.</p>
+</blockquote>
+
+<p>In this exercise, you&rsquo;ll add a d20 dice roll to the Go scheduler&rsquo;s work stealing algorithm. When a processor (P) tries to steal goroutines from another P&rsquo;s run queue, it must first roll above 10 on a twenty-sided die. Failed rolls mean the steal is blocked, making the scheduler&rsquo;s work distribution visible and entertaining.</p>
+
+<h2>Learning Objectives</h2>
+
+<p>By the end of this exercise, you will:</p>
+
+<ul>
+<li>Understand how Go&rsquo;s work stealing scheduler distributes goroutines across processors</li>
+<li>Know where the <code>stealWork</code> function lives and how it iterates over other P&rsquo;s</li>
+<li>Modify the steal logic to add a randomized gate</li>
+<li>Observe work stealing attempts in real time</li>
+</ul>
+
+<h2>Background: Work Stealing</h2>
+
+<p>Go&rsquo;s scheduler uses work stealing to balance load across processors. When a P runs out of goroutines to execute, it looks at other P&rsquo;s queues and steals half their work:</p>
+
+<pre><code>Before (current behavior):
+  P0: [g1, g2, g3, g4]    P1: []  (idle)
+  P1 tries to steal from P0 → always succeeds
+  P0: [g1, g2]             P1: [g3, g4]
+
+After (our modification):
+  P0: [g1, g2, g3, g4]    P1: []  (idle)
+  P1 rolls d20 to steal from P0 → rolled 7, failed!
+  P1 rolls d20 to steal from P0 → rolled 16, stole!
+  P0: [g1, g2]             P1: [g3, g4]
+</code></pre>
+
+<h2>Step 1: Understanding the Steal Mechanism</h2>
+
+<p>The work stealing logic lives in the <code>stealWork</code> function in <code>proc.go</code>:</p>
+
+<pre><code class="language-bash">cd go/src/runtime
+grep -n &quot;func stealWork&quot; proc.go
+</code></pre>
+
+<p>You&rsquo;ll find <code>stealWork</code> around line 3828. This function is called by <code>findRunnable</code> when a P has no local work. It iterates over other P&rsquo;s in a randomized order, trying to steal goroutines from their run queues.</p>
+
+<h2>Step 2: Find the Steal Attempt</h2>
+
+<p>Inside <code>stealWork</code>, look for the actual steal attempt around line 3883:</p>
+
+<pre><code class="language-bash">grep -n &quot;runqsteal&quot; proc.go | head -5
+</code></pre>
+
+<p>You&rsquo;ll see this code block (around line 3883-3887):</p>
+
+<pre><code class="language-go">// go/src/runtime/proc.go:3883-3887
+// Don't bother to attempt to steal if p2 is idle.
+if !idlepMask.read(enum.position()) {
+    if gp := runqsteal(pp, p2, stealTimersOrRunNextG); gp != nil {
+        return gp, false, now, pollUntil, ranTimer
+    }
+}
+</code></pre>
+
+<p>Key variables at this point:
+- <strong><code>pp</code></strong> - The current P (the thief), type <code>*p</code>, has field <code>pp.id</code> (int32)
+- <strong><code>p2</code></strong> - The target P (the victim), type <code>*p</code>, has field <code>p2.id</code>
+- <strong><code>runqsteal(pp, p2, ...)</code></strong> - Moves goroutines from p2&rsquo;s queue to pp&rsquo;s queue</p>
+
+<h2>Step 3: Add the D&amp;D Dice Roll</h2>
+
+<p>Replace lines 3883-3887 with our dice-gated version:</p>
+
+<pre><code class="language-go">// go/src/runtime/proc.go:3883-3887
+// Don't bother to attempt to steal if p2 is idle.
+if !idlepMask.read(enum.position()) {
+    if mainStarted &amp;&amp; gogetenv(&quot;GODND&quot;) != &quot;&quot; {
+        // D&amp;D Work Stealing: Roll a d20 to attempt stealing!
+        roll := cheaprandn(20) + 1 // Roll 1-20
+        if roll &gt; 10 {
+            if gp := runqsteal(pp, p2, stealTimersOrRunNextG); gp != nil {
+                println(&quot;🎲 [P&quot;, pp.id, &quot;] Rolling to steal from P&quot;, p2.id, &quot;... rolled&quot;, roll, &quot;. Stole!&quot;)
+                return gp, false, now, pollUntil, ranTimer
+            }
+        } else {
+            println(&quot;🎲 [P&quot;, pp.id, &quot;] Rolling to steal from P&quot;, p2.id, &quot;... rolled&quot;, roll, &quot;. Failed!&quot;)
+        }
+    } else {
+        if gp := runqsteal(pp, p2, stealTimersOrRunNextG); gp != nil {
+            return gp, false, now, pollUntil, ranTimer
+        }
+    }
+}
+</code></pre>
+
+<h3>Understanding the Code</h3>
+
+<ul>
+<li><strong><code>mainStarted</code></strong> - A boolean already in <code>proc.go</code> that flips to <code>true</code> early in the main goroutine&rsquo;s startup — before <code>sysmon</code>, GC, and <code>init()</code> run. It cuts out the very earliest scheduler noise, but some pre-main prints will still appear (see the callout below)</li>
+<li><strong><code>gogetenv(&quot;GODND&quot;)</code></strong> - The runtime&rsquo;s internal env var reader (equivalent of <code>os.Getenv</code> — the runtime can&rsquo;t import <code>os</code>). Gates everything behind <code>GODND=1</code> so the scheduler behaves normally unless you opt in</li>
+<li><strong><code>cheaprandn(20) + 1</code></strong> - Rolls 1-20. <code>cheaprandn(20)</code> returns 0-19, the <code>+ 1</code> shifts it to a proper d20 range</li>
+<li><strong><code>roll &gt; 10</code></strong> - 50% success rate (rolls 11-20 succeed, rolls 1-10 fail)</li>
+<li><strong><code>println(...)</code></strong> - Runtime&rsquo;s builtin print function, writes to stderr via raw syscall, no imports needed</li>
+<li><strong><code>pp.id</code> / <code>p2.id</code></strong> - The processor ID fields (int32), defined in the <code>p</code> struct in <code>runtime2.go</code></li>
+<li>We only print &ldquo;Stole!&rdquo; when <code>runqsteal</code> returns non-nil (the target queue might have emptied between the idle check and the steal)</li>
+</ul>
+
+<blockquote>
+<p><strong>🐉 Fun fact: The scheduler already rolls with advantage — times four!</strong></p>
+
+<p>Look at the outer loop in <code>stealWork</code>: <code>const stealTries = 4</code>. The scheduler doesn&rsquo;t just try to steal once — it loops <strong>4 times</strong> over all P&rsquo;s, re-shuffling the order with <code>cheaprand()</code> each pass. So your d20 gate doesn&rsquo;t just get rolled once per steal attempt — a determined P gets up to 4 chances per target. In D&amp;D terms, that&rsquo;s rolling with advantage&hellip; squared.</p>
+
+<p>And the 4th pass is special: it sets <code>stealTimersOrRunNextG = true</code>, which unlocks stealing the victim&rsquo;s <code>runnext</code> goroutine — the one it was about to run next. The source code comment literally says <em>&ldquo;stealing from the other P&rsquo;s runnext should be the last resort.&rdquo;</em> So the final pass is the desperate, gloves-off round where everything is fair game.</p>
+
+<p>The Go scheduler was already playing D&amp;D before you got here. You&rsquo;re just making the dice visible.</p>
+</blockquote>
+
+<h2>Step 4: Rebuild Go Toolchain</h2>
+
+<pre><code class="language-bash">cd ../  # back to go/src
+./make.bash
+</code></pre>
+
+<h2>Step 5: Test the D&amp;D Scheduler</h2>
+
+<p>Create the <code>dnd_steal_demo.go</code> file:</p>
+
+<pre><code class="language-bash"># Create the file
+touch /tmp/dnd_steal_demo.go
+</code></pre>
+
+<pre><code class="language-go">package main
+
+import (
+    &quot;runtime&quot;
+    &quot;sync&quot;
+)
+
+func busyWork(id int, wg *sync.WaitGroup) {
+    defer wg.Done()
+    sum := 0
+    for i := 0; i &lt; 1_000_000; i++ {
+        sum += i
+    }
+    println(&quot;Goroutine&quot;, id, &quot;finished&quot;)
+}
+
+func main() {
+    runtime.GOMAXPROCS(4) // 4 P's for visible stealing
+    println(&quot;=== D&amp;D Work Stealing Demo ===&quot;)
+    println()
+
+    var wg sync.WaitGroup
+    for i := 1; i &lt;= 20; i++ {
+        wg.Add(1)
+        go busyWork(i, &amp;wg)
+    }
+    wg.Wait()
+    println()
+    println(&quot;=== All goroutines completed! ===&quot;)
+}
+</code></pre>
+
+<p>Build and run with D&amp;D mode enabled:</p>
+
+<pre><code class="language-bash">../go/bin/go build -o dnd_steal_demo /tmp/dnd_steal_demo.go
+GODND=1 ./dnd_steal_demo
+</code></pre>
+
+<p><strong>Why <code>GODND=1</code>?</strong> Without it, the scheduler runs normally — no dice rolls, no prints. This keeps <code>./make.bash</code> and <code>go build</code> clean and silent. Note that some pre-main and post-main prints will still appear even with <code>GODND=1</code> — see the callouts below for why.</p>
+
+<p><strong>Why build first then run?</strong> The <code>go build</code> command itself uses your modified Go. Building separately (without <code>GODND=1</code>) keeps the compiler&rsquo;s work stealing silent.</p>
+
+<p>Expected output (varies every run):</p>
+
+<pre><code>🎲 [P 3 ] Rolling to steal from P 0 ... rolled 13 . Stole!
+=== D&amp;D Work Stealing Demo ===
+
+🎲 [P 2 ] Rolling to steal from P 0 ... rolled 15 . Stole!
+🎲 [P 3 ] Rolling to steal from P 0 ... rolled 12 . Stole!
+🎲 [P 1 ] Rolling to steal from P 0 ... rolled 11 . Stole!
+Goroutine 15 finished
+🎲 [P 0 ] Rolling to steal from P 2 ... rolled 7 . Failed!
+🎲 [P 0 ] Rolling to steal from P 3 ... rolled 20 . Stole!
+Goroutine 1 finished
+Goroutine 12 finished
+...
+=== All goroutines completed! ===
+🎲 [P %
+</code></pre>
+
+<p>You&rsquo;ll see the dice rolls interleaved with goroutine completion messages. Rolls of 1-10 fail, rolls of 11-20 succeed. Notice how a P with no work keeps retrying different targets until it rolls high enough!</p>
+
+<blockquote>
+<p><strong>📖 Why are there dice rolls before <code>=== D&amp;D Work Stealing Demo ===</code>?</strong></p>
+
+<p>You didn&rsquo;t write those — the Go runtime did. Between <code>mainStarted</code> flipping to <code>true</code> and your first <code>println</code>, the runtime starts <code>sysmon</code>, enables the GC, and runs all <code>init()</code> functions — each spawning goroutines that idle P&rsquo;s immediately try to steal. You&rsquo;ve instrumented the scheduler itself, so you&rsquo;re now seeing activity that was always there, just silent.</p>
+
+<p><strong>📖 Why is there a truncated <code>🎲 [P %</code> after <code>=== All goroutines completed! ===</code>?</strong></p>
+
+<p>Same story, other end. After <code>wg.Wait()</code> returns, the idle P&rsquo;s are still spinning in <code>stealWork</code> looking for more work. One starts a <code>println</code> just as <code>main()</code> returns and the process exits — the print never finishes. The <code>%</code> is your shell saying the output didn&rsquo;t end with a newline. The scheduler doesn&rsquo;t stop for you on the way out either.</p>
+
+<p>Welcome to the inside of Go!</p>
+</blockquote>
+
+<h2>Understanding What We Did</h2>
+
+<ol>
+<li><strong>Found the Steal Logic</strong>: Located <code>stealWork</code> in <code>proc.go</code> where P&rsquo;s steal goroutines from each other</li>
+<li><strong>Added a Dice Gate</strong>: Used <code>cheaprandn(20) + 1</code> to generate a d20 roll (1-20) before each steal attempt</li>
+<li><strong>Logged the Rolls</strong>: Added <code>println()</code> calls showing which P is stealing from which, the roll result, and whether it succeeded</li>
+<li><strong>Observed the Effect</strong>: Saw work stealing attempts in real time, with some failing due to low rolls</li>
+</ol>
+
+<h2>What We Learned</h2>
+
+<ul>
+<li><strong>Work Stealing</strong>: How Go distributes goroutines across processors when queues are imbalanced</li>
+<li><strong><code>stealWork</code> Function</strong>: The core loop that iterates over P&rsquo;s looking for work to steal</li>
+<li><strong><code>cheaprandn</code></strong>: The runtime&rsquo;s fast pseudo-random number generator, used throughout the scheduler</li>
+<li><strong>Scheduler Observability</strong>: How to add logging to the scheduler without breaking its behavior</li>
+<li><strong>P Identity</strong>: Each processor has a unique <code>id</code> field that identifies it in scheduling decisions</li>
+</ul>
+
+<h2>Extension Ideas</h2>
+
+<ol>
+<li>Make the difficulty configurable: roll must beat 15 instead of 10 (harder steals)</li>
+<li>Add a &ldquo;critical hit&rdquo; on natural 20: steal ALL goroutines from target, not just half</li>
+<li>Add a &ldquo;fumble&rdquo; on natural 1: the stealing P yields for one cycle with <code>Gosched()</code></li>
+<li>Track and print total rolls, successes, and failures at program exit</li>
+</ol>
+
+<h2>Cleanup</h2>
+
+<p>To remove the dice roll:</p>
+
+<pre><code class="language-bash">cd go/src/runtime
+git checkout proc.go
+cd ../
+./make.bash
+</code></pre>
+
+<h2>Summary</h2>
+
+<p>You&rsquo;ve turned Go&rsquo;s work stealing scheduler into a tabletop RPG encounter:</p>
+
+<pre><code>Before:  P tries to steal -&gt; always succeeds if target has work
+After:   P tries to steal -&gt; must roll &gt; 10 on a d20 first
+
+Changes: runtime/proc.go stealWork() function (~14 lines)
+Result:  The scheduler now plays D&amp;D!
+</code></pre>
+
+<hr />
+
+<p><em>Congratulations on completing all workshop exercises! Return to the <a href="index.html">main workshop</a></em></p>
+
+        </article>
+
+        <nav class="exercise-nav">
+            
+            <a href="10-java-style-stack-traces.html" class="nav-button">← Previous</a>
+            
+            
+        </nav>
+    </div>
+
+    <footer>
+        <div class="container">
+            <p>Having fun with the Go Source Code</p>
+            <p>Created by <strong>Jesús Espino</strong></p>
+            <div class="footer-links">
+                <a href="https://github.com/jespino" target="_blank"><i class="fab fa-github"></i> GitHub</a>
+                <a href="https://x.com/jespinog" target="_blank"><i class="fab fa-x-twitter"></i> @jespinog</a>
+                <a href="https://linkedin.com/in/jesus-espino" target="_blank"><i class="fab fa-linkedin"></i> LinkedIn</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/website/es/01-compile-go-unchanged.html
+++ b/website/es/01-compile-go-unchanged.html
@@ -284,6 +284,7 @@ func main() {
 <li><a href="08-goroutine-sleep-detective.html">Ejercicio 8: Detective de Goroutines Dormidas - Monitoreo del Estado del Runtime</a> - Monitoreo del scheduler</li>
 <li><a href="09-predictable-select.html">Ejercicio 9: Select Predecible - Eliminar la Aleatoriedad del Select de Go</a> - Comportamiento del select</li>
 <li><a href="10-java-style-stack-traces.html">Ejercicio 10: Stack Traces al Estilo Java - Hacer que los Panics de Go se Vean Familiares</a> - Formato de errores</li>
+<li><a href="11-dnd-work-stealing.html">Ejercicio 11: D&amp;D Work Stealing - Tirando Dados por Goroutines</a> - Work stealing del scheduler</li>
 </ul>
 
 <p>O vuelve al <a href="index.html">taller principal</a> para elegir un ejercicio.</p>

--- a/website/es/10-java-style-stack-traces.html
+++ b/website/es/10-java-style-stack-traces.html
@@ -284,7 +284,7 @@ Exception in thread &quot;main&quot; go.runtime.Panic: ...
 
 <hr />
 
-<p><em>¡Felicidades por completar todos los ejercicios del taller! Vuelve al <a href="index.html">taller principal</a></em></p>
+<p><em>Continúa con el <a href="11-dnd-work-stealing.html">Ejercicio 11</a> o vuelve al <a href="index.html">taller principal</a></em></p>
 
         </article>
 

--- a/website/index.html
+++ b/website/index.html
@@ -74,7 +74,7 @@
 
         <section class="overview">
             <h2>Workshop Overview</h2>
-            <p>This workshop consists of 11 exercises that will take you through the process from building Go from source, and making modifications at different places in the compiler, tooling and runtime. You'll gain some insights about the Go internals, from things like the lexer or parser, to runtime behaviors:</p>
+            <p>This workshop consists of 12 exercises that will take you through the process from building Go from source, and making modifications at different places in the compiler, tooling and runtime. You'll gain some insights about the Go internals, from things like the lexer or parser, to runtime behaviors:</p>
 
             <div class="exercises-grid">
                 
@@ -163,6 +163,14 @@
                         <div class="exercise-number">Exercise 10</div>
                         <h3>Java-Style Stack Traces - Making Go Panics Look Familiar</h3>
                         <p>Transform Go&#39;s verbose stack traces into Java-style formatting.</p>
+                    </div>
+                </a>
+                
+                <a href="11-dnd-work-stealing.html" class="exercise-card-link">
+                    <div class="exercise-card">
+                        <div class="exercise-number">Exercise 11</div>
+                        <h3>D&amp;D Work Stealing - Rolling for Goroutines</h3>
+                        <p>Add a d20 dice roll to Go&#39;s work stealing scheduler to gate goroutine theft between processors.</p>
                     </div>
                 </a>
                 


### PR DESCRIPTION
## "Aha" moments I had during this exercise

### The scheduler's randomness runs deeper than expected

The `stealWork` doesn't just randomize steal order!  it [loops 4 times](https://github.com/golang/go/blob/go1.26.1/src/runtime/proc.go#L3833-L3837) over all P's, and the final pass unlocks stealing runnext (the goroutine the p2 was about to run next). The source calls it "[the last resort](https://github.com/golang/go/blob/go1.26.1/src/runtime/proc.go#L3850)."

### mainStarted flips too early to help us

It's [set to true](https://github.com/golang/go/blob/go1.26.1/src/runtime/proc.go#L139-L171) before `sysmon`, GC, and `init()` run. So our dice rolls appear before  `main()` does.

### make.bash compiles the stdlib with the freshly built Go

The build script uses the new toolchain to rebuild everything — so our scheduler prints leak into the build output before we ever run our own program and that was funny!


 ## Test plan

  - [ ] `./make.bash` builds cleanly with no dice output
  - [ ] `GODND=1 ./dnd_steal_demo` shows dice rolls only during program execution
  - [ ] `make website` generates exercise 11 page and updated index
  - [ ] Navigation links work: exercise 10 → 11, exercise 01 listing, index page
  
  
  Thank you for the idea! it was really cool!